### PR TITLE
Use Monaspace Radon as the default font, with option to turn off

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,6 +7,9 @@ Work in progress, so some colors and color combinations might change slightly. F
 [[./screenshot.png]]
 
 ** Installation and usage
+By default the theme uses the [[https://monaspace.githubnext.com/][Monaspace Radon]] font if available, so make sure to install it if you want to use it!
+
+
 *** Manual
 Clone this repository to a path you can remember on your machine. Then you can simply add it and use in your config:
 #+BEGIN_SRC emacs-lisp
@@ -40,6 +43,23 @@ If you are one of the few who use straight.el, you can install it without manual
 
 (if your local git install suddenly gets really anal on you in this one package: Remove the =:host= argument and put the ssh clone .git file into the =:repo= argument)
 
+
+** Configuration
+*Note: Due to the theme loading a font, and not reverting it, this setting will have to come BEFORE you load the theme! That means before your load-theme call.*
+
+If you have Monaspace Radon installed, but don't want to use it, you can disable it by setting =pink-bliss-uwu-use-custom-font= to =nil=. Example:
+
+#+BEGIN_SRC emacs-lisp
+  (setq pink-bliss-uwu-use-custom-font nil)
+
+  ;; or use-pacakge:
+  (use-package pink-bliss-uwu-theme
+    :load-path "/path/to/theme"
+    :config
+    (load-theme 'pink-bliss-uwu t)
+    :custom
+    (pink-bliss-uwu-use-custom-font nil))
+#+END_SRC
 
 ** Contributing
 Feel free to contribute if you want to :heart:

--- a/pink-bliss-uwu-theme.el
+++ b/pink-bliss-uwu-theme.el
@@ -226,6 +226,21 @@ To check out the list, evaluate
 \(list-colors-display pink-bliss-foreground-colors).")
 
 
+;; Give the users the option to turn off the default font
+(defcustom pink-bliss-uwu-use-custom-font nil
+  "Whether to use Monaspace Radon font or not if it is installed."
+  :group 'pink-bliss-uwu
+  :type 'boolean)
+
+;; Use Monaspace Radon if available and not turned off
+;; https://monaspace.githubnext.com/
+;; (install pls!)
+(let ((desired-font "-*-Monaspace Radon-regular-normal-normal-*-12-*-*-*-p-0-iso10646-1"))
+  (unless (or (null (find-font (font-spec :name desired-font)))
+              (not pink-bliss-uwu-use-custom-font))
+    (set-frame-font desired-font nil t)))
+
+
 ;; Add self to custom theme path
 ;;;###autoload
 (when load-file-name


### PR DESCRIPTION
Like the title says. The reason for making a PR is to have other possible voices in the discussion before merging 🙂 

The only minor issue: As we set a font, but not handle any sort of revert, the on/off-setting described in the README only works during first load. Do any of you know of any clever ways to revert setting a font like we do here? Or if there are better ways to handle custom fonts for themes?


Fixes #2 