### PR TITLE
Fix issue where font is not loading

### DIFF
--- a/pink-bliss-uwu-theme.el
+++ b/pink-bliss-uwu-theme.el
@@ -262,7 +262,7 @@ To check out the list, evaluate
 ;; Use Monaspace Radon if available and not turned off
 ;; https://monaspace.githubnext.com/
 ;; (install pls!)
-(let ((desired-font "-*-Monaspace Radon-regular-normal-normal-*-12-*-*-*-p-0-iso10646-1"))
+(let ((desired-font "-*-Monaspace Radon-regular-normal-normal-*-*-*-*-*-*-iso10646-1"))
   (unless (or (null (find-font (font-spec :name desired-font)))
               (not pink-bliss-uwu-use-custom-font))
     (set-frame-font desired-font nil t)))


### PR DESCRIPTION
Add more wildcards to font spec. This is due to an issue I experienced on my Macbook Air after a homebrew package upgrade (Monaspace Radon was somehow affected). After the package upgrade, Emacs wouldn't load the font anymore. There was some slight changes in spec name, like an `m` instead of a `p` (unsure what they mean as fonts are not really that interesting to read up on). Decided to add some more wildcards to avoid similar issues. The error seem to be a bit system dependent for some reason? My Arch install on my other computer did not seem to have this issue.